### PR TITLE
Bvmu 74 redis util 구현

### DIFF
--- a/src/main/java/com/example/everymutsa/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/everymutsa/api/auth/service/RefreshTokenService.java
@@ -15,23 +15,23 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-	private final RedisTemplate<String, String> redisTemplate;
+	private final RedisTemplate<String, String> refreshTokenRedisTemplate;
 	private final JwtTokenProvider tokenProvider;
 
 	public void save(String email, String token) {
-		redisTemplate.opsForValue()
+		refreshTokenRedisTemplate.opsForValue()
 			.set(email, token, tokenProvider.REFRESH_TOKEN_EXPIRATION_TIME, TimeUnit.MILLISECONDS);
 	}
 
 	public void deleteTokenByEmail(String email) {
-		redisTemplate.delete(email);
+		refreshTokenRedisTemplate.delete(email);
 	}
 
 	public boolean validateToken(String token) {
 		if (!tokenProvider.validateToken(token)) {
 			return false;
 		}
-		String foundToken = redisTemplate.opsForValue().get(tokenProvider.getUsernameFromToken(token));
+		String foundToken = refreshTokenRedisTemplate.opsForValue().get(tokenProvider.getUsernameFromToken(token));
 		return token != null && foundToken.equals(token);
 	}
 

--- a/src/main/java/com/example/everymutsa/config/RedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/RedisConfig.java
@@ -1,37 +1,40 @@
 package com.example.everymutsa.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
 
-	private final String host;
-	private final int port;
+	@Value("${spring.data.redis.host}")
+	private String host;
 
-	public RedisConfig(
-		@Value("${spring.data.redis.host}") String host,
-		@Value("${spring.data.redis.port}") int port) {
-		this.host = host;
-		this.port = port;
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+
+
+	public RedisConnectionFactory createLettuceConnectionFactory(int dbIndex) {
+		final RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+		redisConfiguration.setHostName(host);
+		redisConfiguration.setPort(port);
+		redisConfiguration.setDatabase(dbIndex);
+
+		return new LettuceConnectionFactory(redisConfiguration);
 	}
 
-	@Bean
-	RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
-	}
 
-	@Bean
-	RedisTemplate<String, String> redisTemplate() {
-		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory());
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
-		return redisTemplate;
-	}
 }

--- a/src/main/java/com/example/everymutsa/config/RedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/RedisConfig.java
@@ -1,20 +1,10 @@
 package com.example.everymutsa.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.CachingConfigurerSupport;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {

--- a/src/main/java/com/example/everymutsa/config/RefreshTokenRedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/RefreshTokenRedisConfig.java
@@ -1,0 +1,23 @@
+package com.example.everymutsa.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+public class RefreshTokenRedisConfig extends RedisConfig {
+    @Bean
+    public RedisConnectionFactory refreshTokenRedisConnectionFactory() {
+        return createLettuceConnectionFactory(0);
+    }
+    @Bean
+    @Qualifier("refreshTokenRedisTemplate")
+    RedisTemplate<String, String> refreshTokenRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(refreshTokenRedisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/everymutsa/config/SearchRedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/SearchRedisConfig.java
@@ -1,0 +1,53 @@
+package com.example.everymutsa.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class SearchRedisConfig extends RedisConfig{
+
+    @Bean
+    public RedisConnectionFactory searchRankingRedisConnectionFactory() {
+        return createLettuceConnectionFactory(2); // Redis DB 선택
+    }
+    @Bean(name = "redisTemplate")
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(searchRankingRedisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisSearchCacheManager() {
+        RedisCacheConfiguration redisCacheConfig = CacheConfiguration();
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(searchRankingRedisConnectionFactory())
+                .cacheDefaults(redisCacheConfig)
+                .transactionAware()
+                .build();
+    }
+
+    private RedisCacheConfiguration CacheConfiguration() {
+        // key    문자열을 바이트 배열로 변환하여 저장
+        RedisSerializationContext.SerializationPair<String> keySerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer());
+        // value  값은 객체 형태로 저장 : Java 객체를 JSON 형태로 직렬화하는 설정
+        RedisSerializationContext.SerializationPair<Object> valueSerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(keySerializationPair)
+                .serializeValuesWith(valueSerializationPair);
+    }
+}

--- a/src/main/java/com/example/everymutsa/config/SearchRedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/SearchRedisConfig.java
@@ -1,13 +1,10 @@
 package com.example.everymutsa.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;

--- a/src/main/java/com/example/everymutsa/config/ViewCountRedisConfig.java
+++ b/src/main/java/com/example/everymutsa/config/ViewCountRedisConfig.java
@@ -1,0 +1,55 @@
+package com.example.everymutsa.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class ViewCountRedisConfig extends RedisConfig{
+
+    @Bean
+    public RedisConnectionFactory viewCountConnectionFactory() {
+        return createLettuceConnectionFactory(1); // Redis DB 선택
+    }
+
+    @Bean
+    @Qualifier("viewCountRedisTemplate")
+    public RedisTemplate<String, String> viewCountRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(viewCountConnectionFactory());
+        return redisTemplate;
+    }
+
+
+    @Bean
+    public RedisCacheManager redisViewCountCacheManager() {
+        RedisCacheConfiguration redisCacheConfig = CacheConfiguration();
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(viewCountConnectionFactory())
+                .cacheDefaults(redisCacheConfig)
+                .transactionAware()
+                .build();
+    }
+
+    private RedisCacheConfiguration CacheConfiguration() {
+        // key    문자열을 바이트 배열로 변환하여 저장
+        RedisSerializationContext.SerializationPair<String> keySerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer());
+        // value  값은 객체 형태로 저장 : Java 객체를 JSON 형태로 직렬화하는 설정
+        RedisSerializationContext.SerializationPair<Object> valueSerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(keySerializationPair)
+                .serializeValuesWith(valueSerializationPair);
+    }
+}

--- a/src/main/java/com/example/everymutsa/utils/redis/SearchRankingRedisUtils.java
+++ b/src/main/java/com/example/everymutsa/utils/redis/SearchRankingRedisUtils.java
@@ -1,0 +1,45 @@
+package com.example.everymutsa.utils.redis;
+
+import com.example.everymutsa.utils.redis.dto.CachingResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class SearchRankingRedisUtils {
+    private static RedisTemplate<String, String> redisSearchTemplate;
+    private static final String rankingKey = "search_ranking";
+
+    @Autowired
+    private SearchRankingRedisUtils(@Qualifier("redisTemplate") RedisTemplate<String, String> redisSearchTemplate)  {
+        SearchRankingRedisUtils.redisSearchTemplate=redisSearchTemplate;
+    }
+
+    public static void addSearchKeyword(String searchString) {
+        for(String keyword : searchString.split(" "))
+            redisSearchTemplate.opsForZSet().incrementScore(rankingKey, keyword, 1);
+    }
+
+    public static List<CachingResponse> readTopSearchKeywords(int count) {
+        Set<ZSetOperations.TypedTuple<String>> result = redisSearchTemplate.opsForZSet().reverseRangeWithScores(rankingKey, 0, count - 1);
+
+        List<CachingResponse> topKeywords = new ArrayList<>();
+        for (ZSetOperations.TypedTuple<String> tuple : result) {
+            topKeywords.add(CachingResponse.builder(
+                    topKeywords.size() + 1,
+                    tuple.getValue(),
+                    tuple.getScore()
+            ));
+        }
+        return topKeywords;
+    }
+
+
+}

--- a/src/main/java/com/example/everymutsa/utils/redis/ViewCountRedisUtils.java
+++ b/src/main/java/com/example/everymutsa/utils/redis/ViewCountRedisUtils.java
@@ -1,0 +1,45 @@
+package com.example.everymutsa.utils.redis;
+
+import com.example.everymutsa.utils.redis.dto.CachingResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@Slf4j
+public class ViewCountRedisUtils {
+    private static RedisTemplate<String, String> redisTemplate;
+    private static final String rankingKey = "view_count";
+    @Autowired
+    private ViewCountRedisUtils(@Qualifier("viewCountRedisTemplate") RedisTemplate<String, String> redisViewCountTemplate) {
+        ViewCountRedisUtils.redisTemplate = redisViewCountTemplate;
+    }
+
+    public static void addViewCount(Long postId) {
+        redisTemplate.opsForZSet().incrementScore(rankingKey, String.valueOf(postId), 1);
+    }
+
+    public static List<CachingResponse> readTopViewCount(int count) {
+        Set<ZSetOperations.TypedTuple<String>> result = redisTemplate.opsForZSet().reverseRangeWithScores(rankingKey, 0, count - 1);
+
+        List<CachingResponse> topKeywords = new ArrayList<>();
+        for (ZSetOperations.TypedTuple<String> tuple : result) {
+            topKeywords.add(CachingResponse.builder(
+                    topKeywords.size() + 1,
+                    tuple.getValue(),
+                    tuple.getScore()
+            ));
+        }
+        return topKeywords;
+    }
+
+}

--- a/src/main/java/com/example/everymutsa/utils/redis/ViewCountRedisUtils.java
+++ b/src/main/java/com/example/everymutsa/utils/redis/ViewCountRedisUtils.java
@@ -5,12 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/com/example/everymutsa/utils/redis/dto/CachingResponse.java
+++ b/src/main/java/com/example/everymutsa/utils/redis/dto/CachingResponse.java
@@ -1,0 +1,20 @@
+package com.example.everymutsa.utils.redis.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class CachingResponse {
+    private Integer ranking;
+    private Object keyword;
+    private Double score;
+
+    @Builder
+    public static CachingResponse builder(Integer ranking, Object keyword, Double score) {
+        CachingResponse response = new CachingResponse();
+        response.ranking = ranking;
+        response.keyword = keyword;
+        response.score = score;
+        return response;
+    }
+}

--- a/src/test/java/com/example/everymutsa/utils/RedisSearchUtilsTest.java
+++ b/src/test/java/com/example/everymutsa/utils/RedisSearchUtilsTest.java
@@ -1,0 +1,37 @@
+package com.example.everymutsa.utils;
+
+import com.example.everymutsa.utils.redis.SearchRankingRedisUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@SpringBootTest
+@Slf4j
+class RedisSearchUtilsTest {
+    @Test
+    void SearchKeywordTest() {
+        //given
+        String[] keywords = {
+                "apple", "banana", "cherry", "date", "elderberry", "fig", "grape",
+                "apple",
+                "apple", "banana",
+                "apple", "banana",
+                "apple", "banana", "cherry", "date",
+                "apple", "banana", "cherry", "date", "elderberry",
+                "apple", "banana", "cherry", "date", "elderberry", "fig",
+                "apple", "banana", "cherry", "date", "elderberry", "fig", "grape",
+                "cherry","cherry", "cherry","cherry","cherry","cherry","cherry","cherry","cherry",
+        };
+
+        //when
+        for(String keyword : keywords) SearchRankingRedisUtils.addSearchKeyword(keyword);
+
+        //then
+        log.info(SearchRankingRedisUtils.readTopSearchKeywords(3).toString());
+        Assertions.assertEquals(SearchRankingRedisUtils.readTopSearchKeywords(3).get(0).getKeyword(), "cherry");
+
+    }
+
+}

--- a/src/test/java/com/example/everymutsa/utils/RedisSearchUtilsTest.java
+++ b/src/test/java/com/example/everymutsa/utils/RedisSearchUtilsTest.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.junit.jupiter.api.Assertions;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 @SpringBootTest
 @Slf4j


### PR DESCRIPTION
<!--
PR을 올리기 전에 아래의 항목을 체크해주세요.

1. 작업 내용에 대해 명확하게 설명했는지
2. 새로운 기능/버그 수정 관련된 테스트를 작성했는지
3. 이 PR이 기존 코드에 미치는 영향에 대해 분석했는지
4. 변경 사항이 대단히 크지 않아서 리뷰어가 이해하기 쉬운지
-->

# :dart: PR 주제

RedisUtil 구현
- 조회수 / 검색어

# :eyes: 리뷰 포인트

- CachingResponse : Ranking 정보 출력 Dto
- RedisConfig : 여러개의 DB 사용을 위해 구조 변경, 하위 클래스가 상속하여 사용
---
- RefreshTokenRedisConfig : refresh Token Config, 0번DB 사용
-- RefreshTokenService : redisTemplate -> refreshTokenRedisTemplate 이름 변경
- ViewCountRedisConfig : 조회수, 1번DB 사용
- SearchRankingRedisUtils : 검색어 합산, 2번DB 사용
---
현재는 ViewCount / SearchRanking 사이에 별다른 차이 없으나 이후 추가 구현
사용 DB Notion에 정리
---

# :link: 참조 자료

변경에 대한 추가적인 정보나 레퍼런스가 있다면 링크를 첨부해주세요. (예: 목업, 변경 설명 등)

# :wrench: 변경 유형

관련이 없는 옵션은 삭제해주세요.

- [ ] 새로운 기능 (기존 기능과 호환됨)
