### PR TITLE
BVMU 82 BoardType 문자열 추가

### DIFF
--- a/src/main/java/com/example/everymutsa/web/board/domain/enums/BoardType.java
+++ b/src/main/java/com/example/everymutsa/web/board/domain/enums/BoardType.java
@@ -1,7 +1,17 @@
 package com.example.everymutsa.web.board.domain.enums;
 
 public enum BoardType {
-	NOTICE,
-	QUESTION,
-	COMMUNITY
+	NOTICE("공지사항"),
+	QUESTION("질문사항"),
+	COMMUNITY("커뮤니티");
+
+	private final String type;
+
+	BoardType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return this.type;
+	}
 }


### PR DESCRIPTION

# :dart: PR 주제

Enum 상수에 문자열 연결

# :eyes: 리뷰 포인트

Service에서 BoardType을 구분해줄 때 String값이 필요해서 추가했습니다.

# :link: 참조 자료

변경에 대한 추가적인 정보나 레퍼런스가 있다면 링크를 첨부해주세요. (예: 목업, 변경 설명 등)

# :wrench: 변경 유형

관련이 없는 옵션은 삭제해주세요.

- [ ] 새로운 기능 (기존 기능과 호환됨)

